### PR TITLE
PE Dry Run Bug Fix - AddRecipeCommand

### DIFF
--- a/KitchenLogs.log
+++ b/KitchenLogs.log
@@ -1,16 +1,2 @@
-Mar 29, 2020 11:34:06 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
+Apr 01, 2020 8:37:09 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
 WARNING: An IndexOutOfBounds exception has been caught
-Mar 29, 2020 11:34:10 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught
-Mar 29, 2020 11:34:13 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught
-Mar 29, 2020 8:35:54 PM seedu.kitchenhelper.parser.Parser prepareDeleteRecipe
-WARNING: An IndexOutOfBounds exception has been caught
-Mar 29, 2020 8:36:08 PM seedu.kitchenhelper.parser.Parser prepareDeleteRecipe
-WARNING: An IndexOutOfBounds exception has been caught
-Mar 29, 2020 8:36:27 PM seedu.kitchenhelper.command.DeleteRecipeCommand deleteRecipe
-INFO: A recipe has been deleted
-Mar 29, 2020 8:38:16 PM seedu.kitchenhelper.parser.Parser prepareAddRecipe
-WARNING: An IO exception has been caught
-Mar 29, 2020 8:38:21 PM seedu.kitchenhelper.parser.Parser prepareAddRecipe
-WARNING: An IO exception has been caught

--- a/KitchenLogs.log
+++ b/KitchenLogs.log
@@ -1,2 +1,0 @@
-Apr 01, 2020 8:37:09 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught

--- a/KitchenLogs.log
+++ b/KitchenLogs.log
@@ -1,4 +1,0 @@
-Apr 02, 2020 12:50:50 AM seedu.kitchenhelper.object.Recipe createIngr
-WARNING: An unidentifiable ingredient has been added to ingredient of Miscellaneous category
-Apr 02, 2020 12:50:50 AM seedu.kitchenhelper.command.AddRecipeCommand addRecipe
-INFO: A new recipe has been added

--- a/KitchenLogs.log
+++ b/KitchenLogs.log
@@ -1,0 +1,4 @@
+Apr 02, 2020 12:01:18 PM seedu.kitchenhelper.command.AddIngredientCommand execute
+INFO: A new ingredient has been added
+Apr 02, 2020 12:01:28 PM seedu.kitchenhelper.command.AddRecipeCommand addRecipe
+INFO: A new recipe has been added

--- a/KitchenLogs.log
+++ b/KitchenLogs.log
@@ -1,0 +1,4 @@
+Apr 02, 2020 12:50:50 AM seedu.kitchenhelper.object.Recipe createIngr
+WARNING: An unidentifiable ingredient has been added to ingredient of Miscellaneous category
+Apr 02, 2020 12:50:50 AM seedu.kitchenhelper.command.AddRecipeCommand addRecipe
+INFO: A new recipe has been added

--- a/KitchenLogs.log.1
+++ b/KitchenLogs.log.1
@@ -1,2 +1,0 @@
-Apr 02, 2020 12:51:45 AM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught

--- a/KitchenLogs.log.1
+++ b/KitchenLogs.log.1
@@ -1,2 +1,2 @@
-Mar 29, 2020 11:35:35 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
+Apr 02, 2020 12:51:45 AM seedu.kitchenhelper.parser.Parser prepareListRecipe
 WARNING: An IndexOutOfBounds exception has been caught

--- a/KitchenLogs.log.2
+++ b/KitchenLogs.log.2
@@ -1,2 +1,0 @@
-Mar 29, 2020 11:36:31 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught

--- a/KitchenLogs.log.3
+++ b/KitchenLogs.log.3
@@ -1,2 +1,0 @@
-Mar 29, 2020 11:37:20 PM seedu.kitchenhelper.parser.Parser prepareListRecipe
-WARNING: An IndexOutOfBounds exception has been caught

--- a/outputIngredient.txt
+++ b/outputIngredient.txt
@@ -1,0 +1,1 @@
+/n chicken /c meat /q 8 /p 20.0 /e 18/10/2020

--- a/outputRecipe.txt
+++ b/outputRecipe.txt
@@ -1,1 +1,2 @@
-/n Chicken Salad [/n Chicken Breast /c meat /q 2 /p 0.0 /e null, /n Lettuce /c vegetable /q 4 /p 0.0 /e null] 2
+/n Chicken Salad [/n Lettuce /c vegetable /q 4 /p 0.0 /e null, /n Chicken Breast /c meat /q 2 /p 0.0 /e null] 2
+/n fried chicken [/n chicken /c drink /q 1 /p 0.0 /e null, /n chicken /c meat /q 1 /p 0.0 /e null] 2

--- a/src/main/java/seedu/kitchenhelper/command/AddRecipeCommand.java
+++ b/src/main/java/seedu/kitchenhelper/command/AddRecipeCommand.java
@@ -68,6 +68,8 @@ public class AddRecipeCommand extends Command {
     public String addRecipe(String attributes, ArrayList<Recipe> recipeList) throws KitchenHelperException {
         Recipe freshRecipe = new Recipe();
         freshRecipe.setRecipeName(attributes);
+        System.out.println("Hello im in addRecipe!");
+        System.out.println(freshRecipe.getRecipeName());
         if (checkIfRecipeExist(freshRecipe.getRecipeName(), recipeList)) {
             throw new KitchenHelperException("There is an existing recipe!");
         }

--- a/src/main/java/seedu/kitchenhelper/command/AddRecipeCommand.java
+++ b/src/main/java/seedu/kitchenhelper/command/AddRecipeCommand.java
@@ -68,8 +68,6 @@ public class AddRecipeCommand extends Command {
     public String addRecipe(String attributes, ArrayList<Recipe> recipeList) throws KitchenHelperException {
         Recipe freshRecipe = new Recipe();
         freshRecipe.setRecipeName(attributes);
-        System.out.println("Hello im in addRecipe!");
-        System.out.println(freshRecipe.getRecipeName());
         if (checkIfRecipeExist(freshRecipe.getRecipeName(), recipeList)) {
             throw new KitchenHelperException("There is an existing recipe!");
         }

--- a/src/main/java/seedu/kitchenhelper/command/CookRecipeCommand.java
+++ b/src/main/java/seedu/kitchenhelper/command/CookRecipeCommand.java
@@ -135,7 +135,9 @@ public class CookRecipeCommand extends Command {
         boolean isSufficient = true;
         for (Ingredient ingr : recipeToBeCooked.getRecipeItem()) {
             int totalCookedQty = pax * ingr.getQuantity();
-            if (getIngredientQty(ingr.getIngredientName().toLowerCase(), ingredientList) < totalCookedQty) {
+            String ingrName = ingr.getIngredientName().toLowerCase();
+            String ingrCategory = ingr.getCategoryName().toLowerCase();
+            if (getIngredientQty(ingrName, ingrCategory, ingredientList) < totalCookedQty) {
                 isSufficient = false;
             }
         }
@@ -149,10 +151,11 @@ public class CookRecipeCommand extends Command {
      * @param ingredientList    the list of ingredients available.
      * @return the quantity of ingredients with the same name.
      */
-    public int getIngredientQty(String ingrName, ArrayList<Ingredient> ingredientList) {
+    public int getIngredientQty(String ingrName, String ingrCategory, ArrayList<Ingredient> ingredientList) {
         int availableIngrCount = 0;
         for (Ingredient ingr : ingredientList) {
-            if (ingr.getIngredientName().equalsIgnoreCase(ingrName)) {
+            if (ingr.getIngredientName().equalsIgnoreCase(ingrName)
+                    && ingr.getCategoryName().equalsIgnoreCase(ingrCategory)) {
                 availableIngrCount += ingr.getQuantity();
             }
         }

--- a/src/main/java/seedu/kitchenhelper/parser/Parser.java
+++ b/src/main/java/seedu/kitchenhelper/parser/Parser.java
@@ -116,11 +116,11 @@ public class Parser {
             for (int i = 0; i < splitedIngr.length; i++) {
                 String item = splitedIngr[i];
                 String[] ingrContent = item.split(":");
-                int qty = Integer.parseInt(ingrContent[1]);
-                if (ingrContent[0].length() < 1 || qty < 1) {
+                if (!checkAddRecipeIngrValidity(item, ingrContent)) {
                     return new InvalidCommand(
                             String.format("%s\n%s", InvalidCommand.MESSAGE_INVALID, AddRecipeCommand.COMMAND_FORMAT));
                 }
+                System.out.println("hello:" + ingrContent[2]);
                 String[] nameAndType = new String[2];
                 nameAndType[0] = ingrContent[0];
                 nameAndType[1] = ingrContent[2];
@@ -133,6 +133,18 @@ public class Parser {
         }
         addCmd.setAttributesOfCmd(attributes, ingrAndQty);
         return addCmd;
+    }
+
+    public Boolean checkAddRecipeIngrValidity(String item, String[] ingrContent) {
+        Boolean isValid = true;
+        int lenOfCmd = ingrContent[0].length();
+        int qtyOfIngr = Integer.parseInt(ingrContent[1]);
+        int separatorCounter = item.length() - item.replace(":", "").length();
+        System.out.println(separatorCounter);
+        if (lenOfCmd < 1 || qtyOfIngr < 1 || separatorCounter > 2) {
+            isValid = false;
+        }
+        return isValid;
     }
 
     /**

--- a/src/main/java/seedu/kitchenhelper/parser/Parser.java
+++ b/src/main/java/seedu/kitchenhelper/parser/Parser.java
@@ -116,7 +116,8 @@ public class Parser {
             for (int i = 0; i < splitedIngr.length; i++) {
                 String item = splitedIngr[i];
                 String[] ingrContent = item.split(":");
-                if (ingrContent[0].length() < 1) {
+                int qty = Integer.parseInt(ingrContent[1]);
+                if (ingrContent[0].length() < 1 || qty < 1) {
                     return new InvalidCommand(
                             String.format("%s\n%s", InvalidCommand.MESSAGE_INVALID, AddRecipeCommand.COMMAND_FORMAT));
                 }

--- a/src/main/java/seedu/kitchenhelper/parser/Parser.java
+++ b/src/main/java/seedu/kitchenhelper/parser/Parser.java
@@ -138,6 +138,12 @@ public class Parser {
         return addCmd;
     }
 
+    /**
+     * Checker for command format for addrecipe command.
+     *
+     * @param command   The full user input without keyword.
+     * @return  true if is of valid command, otherwise false.
+     */
     public Boolean checkAddRecipeCmdFormat(String command) {
         Boolean isValid = true;
         String cmd = command;

--- a/src/main/java/seedu/kitchenhelper/parser/Parser.java
+++ b/src/main/java/seedu/kitchenhelper/parser/Parser.java
@@ -120,7 +120,6 @@ public class Parser {
                     return new InvalidCommand(
                             String.format("%s\n%s", InvalidCommand.MESSAGE_INVALID, AddRecipeCommand.COMMAND_FORMAT));
                 }
-                System.out.println("hello:" + ingrContent[2]);
                 String[] nameAndType = new String[2];
                 nameAndType[0] = ingrContent[0];
                 nameAndType[1] = ingrContent[2];
@@ -135,12 +134,18 @@ public class Parser {
         return addCmd;
     }
 
+    /**
+     * Checker for prepareAddRecipe on the user input.
+     *
+     * @param item          Original string.
+     * @param ingrContent   List of ingredients.
+     * @return true if none of the conditions are violated, false otherwise.
+     */
     public Boolean checkAddRecipeIngrValidity(String item, String[] ingrContent) {
         Boolean isValid = true;
         int lenOfCmd = ingrContent[0].length();
         int qtyOfIngr = Integer.parseInt(ingrContent[1]);
         int separatorCounter = item.length() - item.replace(":", "").length();
-        System.out.println(separatorCounter);
         if (lenOfCmd < 1 || qtyOfIngr < 1 || separatorCounter > 2) {
             isValid = false;
         }

--- a/src/main/java/seedu/kitchenhelper/parser/Parser.java
+++ b/src/main/java/seedu/kitchenhelper/parser/Parser.java
@@ -110,6 +110,10 @@ public class Parser {
         HashMap<String[], Integer> ingrAndQty = new HashMap<>();
         String ingredientList;
         AddRecipeCommand addCmd = new AddRecipeCommand();
+        if (!checkAddRecipeCmdFormat(attributes)) {
+            return new InvalidCommand(
+                    String.format("%s\n%s", InvalidCommand.MESSAGE_INVALID, AddRecipeCommand.COMMAND_FORMAT));
+        }
         try {
             ingredientList = attributes.substring(attributes.indexOf("/i") + 3);
             String[] splitedIngr = ingredientList.split("[,][\\s]");
@@ -132,6 +136,20 @@ public class Parser {
         }
         addCmd.setAttributesOfCmd(attributes, ingrAndQty);
         return addCmd;
+    }
+
+    public Boolean checkAddRecipeCmdFormat(String command) {
+        Boolean isValid = true;
+        String cmd = command;
+        int sepCountForSlashN = cmd.length() - (cmd.replace("/n", "a").length());
+        cmd = cmd.replace("/n", "a");
+        int sepCountForSlashI = cmd.length() - (cmd.replace("/i", "a").length());
+        cmd = cmd.replace("/i", "a");
+        int sepCountForSlashOnly = cmd.length() - (cmd.replace("/", "").length());
+        if (sepCountForSlashN > 1 || sepCountForSlashI > 1 || sepCountForSlashOnly > 0) {
+            isValid = false;
+        }
+        return isValid;
     }
 
     /**


### PR DESCRIPTION
The following has been added:
- fixed the negative addition of quantity for `addrecipe`
This closes #194 and subsequently closes #193.

- fixed the flagging of  missing `,` in command as an invalid command.
This closes #211

- multiple ghost parameters and extra (i.e. `/` and multiple `/n`)
This closes #181, closes #182 and closes #189

- cooks a recipe with the corresponding `ingredient_name` and `category`
This closes #209 and closes #210 